### PR TITLE
2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.1.1] - TBD
+### Added
+- You can now turn on/off looting of rare item drops even if they are blacklisted.
+- Updated blacklist to use NoTradeNoDestroy flag, to ensure looting of important quest items.
+
+### Loot UI
+- Added a setting to toggle looting of rare item drops even if they are blacklisted.
+
 ## [2.1.0] - 11/4/2025
 ### Added
 - The Whitelist loot method has been implemented. 

--- a/Erenshor.LootManager.csproj
+++ b/Erenshor.LootManager.csproj
@@ -96,6 +96,7 @@
       <Compile Include="LootLists\LootWhitelist.cs" />
       <Compile Include="LootManagerController.cs" />
       <Compile Include="LootMethods\BankLoot.cs" />
+      <Compile Include="LootMethods\BlacklistLoot.cs" />
       <Compile Include="LootMethods\StandardLoot.cs" />
       <Compile Include="LootMethods\WhitelistLoot.cs" />
       <Compile Include="LootUI.cs" />

--- a/LootMethods/BlacklistLoot.cs
+++ b/LootMethods/BlacklistLoot.cs
@@ -1,0 +1,27 @@
+namespace LootManager
+{
+    public static class BlacklistLoot
+    {
+        public static bool ShouldLoot(Item item, int quantity)
+        {
+            if (item == null || string.IsNullOrWhiteSpace(item.ItemName))
+                return false;
+            
+            if (item.NoTradeNoDestroy)
+                return false;
+            
+            if (Plugin.LootRare.Value && item.RequiredSlot != Item.SlotType.General)
+            {
+                if (quantity >= 2)
+                    return false;
+            }
+
+            string itemName = item.ItemName;
+            
+            if (Plugin.Blacklist.Contains(itemName))
+                return true;
+            
+            return false;
+        }
+    }
+}

--- a/LootUI/BlacklistPanelController.cs
+++ b/LootUI/BlacklistPanelController.cs
@@ -17,6 +17,7 @@ namespace LootManager
         private TMP_InputField _blackfilterInput;
         private Button _blackaddBtn;
         private Button _blackremoveBtn;
+        private Toggle _lootRareToggle;
         private GameObject _dragHandle;
 
         private UIVirtualList _leftList;
@@ -53,6 +54,7 @@ namespace LootManager
             _blackfilterInput      = UICommon.Find(_root, "container/panelBGblacklist/blacklistPanel/blacklistFilter")?.GetComponent<TMP_InputField>();
             _blackaddBtn           = UICommon.Find(_root, "container/panelBGblacklist/blacklistPanel/blackaddBtn")?.GetComponent<Button>();
             _blackremoveBtn        = UICommon.Find(_root, "container/panelBGblacklist/blacklistPanel/blackremoveBtn")?.GetComponent<Button>();
+            _lootRareToggle        = UICommon.Find(_root, "container/panelBGblacklist/blacklistPanel/blacklootrare")?.GetComponent<Toggle>();
             _dragHandle            = UICommon.Find(_root, "container/panelBGblacklist/lootUIDragHandle")?.gameObject;
 
             if (_dragHandle != null && _containerRect != null)
@@ -91,6 +93,7 @@ namespace LootManager
             _debounce = DebounceInvoker.Attach(_root);
 
             BuildVirtualLists();
+            SetupLootRareToggle();
         }
 
         private void BuildVirtualLists()
@@ -107,6 +110,14 @@ namespace LootManager
 
             _leftList.Enable(true);
             _rightList.Enable(true);
+        }
+        
+        private void SetupLootRareToggle()
+        {
+            if (_lootRareToggle == null) return;
+            _lootRareToggle.SetIsOnWithoutNotify(Plugin.LootRare.Value);
+            _lootRareToggle.onValueChanged.RemoveAllListeners();
+            _lootRareToggle.onValueChanged.AddListener(v => { Plugin.LootRare.Value = v; });
         }
 
         public void Show()

--- a/Patches/LootWindowPatch.cs
+++ b/Patches/LootWindowPatch.cs
@@ -26,7 +26,7 @@ namespace LootManager
 
                 string name = item.ItemName;
                 
-                if (lootMethod == "Blacklist" && Plugin.Blacklist.Contains(name))
+                if (lootMethod == "Blacklist" && BlacklistLoot.ShouldLoot(item, qty))
                 {
                     UpdateSocialLog.LogAdd($"[Loot Manager] Destroyed \"{name}\"", "grey");
                     slot.MyItem   = GameData.PlayerInv.Empty;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace LootManager
 {
-    [BepInPlugin("et508.erenshor.lootmanager", "Loot Manager", "2.1.0")]
+    [BepInPlugin("et508.erenshor.lootmanager", "Loot Manager", "2.1.1")]
     [BepInProcess("Erenshor.exe")]
     public class Plugin : BaseUnityPlugin
     {
@@ -37,6 +37,7 @@ namespace LootManager
         public static ConfigEntry<int>   BankPageFirst;
         public static ConfigEntry<int>   BankPageLast;
         public static ConfigEntry<bool> BankslotAddToList;
+        public static ConfigEntry<bool>  LootRare;
         public static ConfigEntry<bool>  LootEquipment;
         public static ConfigEntry<EquipmentTierSetting> LootEquipmentTier;
 
@@ -59,6 +60,7 @@ namespace LootManager
             BankPageLast             = Config.Bind("Bankloot Settings", "Bank Page Last", 20, new ConfigDescription("Last bank page to use when in Page Range mode.", new AcceptableValueRange<int>(1, 98)));
             BankslotAddToList        = Config.Bind("Bankloot Settings", "Bankslot Add", false, "If true, items sent to the bank with the inventory Bankslot will be added to the Banklist.");
 
+            LootRare                 = Config.Bind("Filter Settings", "Loot Rare Equipment", false, "If true, always loot rare equipment in blacklist loot method.");    
             LootEquipment            = Config.Bind("Filter Settings", "Loot Equipment", true, "If true, loot all equipment.");
             LootEquipmentTier        = Config.Bind("Filter Settings", "Loot Equipment Tier", EquipmentTierSetting.All, "Which tiers of equipment to loot: All, Normal Only, Blessed Only, Godly Only, Blessed and Up.");
             


### PR DESCRIPTION
This pull request adds a new option to control looting of rare item drops when using the blacklist loot method, updates the blacklist logic to use the `NoTradeNoDestroy` flag for better handling of quest items, and introduces corresponding UI and configuration changes. The main changes are grouped below:

Looting logic and configuration:

* Added a new configuration option `LootRare` to allow users to toggle looting of rare item drops even if they are blacklisted (`Plugin.cs`, `BlacklistLoot.cs`). [[1]](diffhunk://#diff-5a2f4e90167632d0df9d167fad586935062628fbbe8cb69ac5c0415663fac33aR40) [[2]](diffhunk://#diff-5a2f4e90167632d0df9d167fad586935062628fbbe8cb69ac5c0415663fac33aR63) [[3]](diffhunk://#diff-ea433c6a5b05aef504bca538a1958e84f0820a68e6f450e2921e36acfa350078R1-R27)
* Updated the blacklist logic to use the `NoTradeNoDestroy` flag, ensuring important quest items are not looted or destroyed (`BlacklistLoot.cs`).
* Modified the loot handling patch to use the new `BlacklistLoot.ShouldLoot` method for determining if an item should be looted when using the blacklist method (`LootWindowPatch.cs`).

UI enhancements:

* Added a toggle in the blacklist panel UI to control the new "loot rare" setting, and ensured the toggle is synced with the configuration (`BlacklistPanelController.cs`). [[1]](diffhunk://#diff-dcaf7007e0eda1da037a1b85124342cd61287239ca00050ab2e6836f1cbf14eaR20) [[2]](diffhunk://#diff-dcaf7007e0eda1da037a1b85124342cd61287239ca00050ab2e6836f1cbf14eaR57) [[3]](diffhunk://#diff-dcaf7007e0eda1da037a1b85124342cd61287239ca00050ab2e6836f1cbf14eaR96) [[4]](diffhunk://#diff-dcaf7007e0eda1da037a1b85124342cd61287239ca00050ab2e6836f1cbf14eaR115-R122)

General updates:

* Updated the changelog to document the new features and changes (`CHANGELOG.md`).
* Bumped the plugin version to 2.1.1 (`Plugin.cs`).
* Added the new `BlacklistLoot.cs` file to the project (`Erenshor.LootManager.csproj`).